### PR TITLE
feat: add support for github actions

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -37,6 +37,13 @@ spec:
             if [ -d "/workspace/source/charts/$REPO_NAME" ]; then source .jx/variables.sh
             cd /workspace/source/charts/$REPO_NAME
             make release; else echo no charts; fi
+        - image: gcr.io/jenkinsxio/jx-boot:3.0.773
+          name: set-github-action-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+            sed -i -e "s/jx-release-version:[0-9\.]*/jx-release-version:$VERSION/" action.yml
         - name: changelog
           resources: {}
         - name: upload-binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM gcr.io/jenkinsxio/jx-cli-base:0.0.21
-
-ENTRYPOINT ["jx-release-version"]
+FROM alpine:3.13
 
 COPY ./build/linux/jx-release-version /usr/bin/jx-release-version
+COPY ./hack/github-actions-entrypoint.sh /usr/bin/github-actions-entrypoint.sh
+
+ENTRYPOINT ["jx-release-version"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,27 @@
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
+name: 'jx-release-version'
+description: 'https://github.com/jenkins-x-plugins/jx-release-version'
+inputs:
+  previous-version:
+    description: 'The strategy to detect the previous version: auto, from-tag, from-file or manual'
+    required: false
+    default: 'auto'
+  next-version:
+    description: 'The strategy to calculate the next version: auto, semantic, from-file, increment or manual'
+    required: false
+    default: 'auto'
+  output-format:
+    description: 'The output format of the next version'
+    required: false
+    default: '{{.Major}}.{{.Minor}}.{{.Patch}}'
+outputs:
+  version:
+    description: 'The next release version'
+runs:
+  using: 'docker'
+  image: 'docker://gcr.io/jenkinsxio/jx-release-version:2.1.0'
+  entrypoint: 'github-actions-entrypoint.sh'
+  env:
+    PREVIOUS_VERSION: ${{ inputs.previous-version }}
+    NEXT_VERSION: ${{ inputs.next-version }}
+    OUTPUT_FORMAT: ${{ inputs.output-format }}

--- a/hack/github-actions-entrypoint.sh
+++ b/hack/github-actions-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -le
+
+version=$(jx-release-version)
+echo "::set-output name=version::$version"


### PR DESCRIPTION
so that this repo can now be used as a github action directly - using the docker integration
we're re-using the existing docker image - just with an extra entrypoint only used by github actions

note that I'm also changing the base image of the docker image, to get a smaller final image
(the previous one was > 2 GB)