### PR TITLE
fix: commits iteration

### DIFF
--- a/strategy/semantic/semantic.go
+++ b/strategy/semantic/semantic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 	"github.com/zbindenren/cc"
 )
@@ -117,8 +118,8 @@ func (s Strategy) parseCommitsSince(repo *git.Repository, firstCommit *object.Co
 
 	err = commitIterator.ForEach(func(commit *object.Commit) error {
 		if commit.Hash == firstCommit.Hash {
-			log.Logger().Debugf("Skipping first commit %s", commit.Hash)
-			return nil
+			log.Logger().Debugf("Skipping first commit %s and stopping iteration", commit.Hash)
+			return storer.ErrStop
 		}
 		log.Logger().Debugf("Parsing commit %s", commit.Hash)
 		c, err := cc.Parse(commit.Message)


### PR DESCRIPTION
fix issue from https://kubernetes.slack.com/archives/C9MBGQJRH/p1616037666094000

```
DEBUG: jx-release-version 2.2.4 running in debug mode in <path>
DEBUG: Using "auto" version reader (with "")
DEBUG: Trying to read the previous version from the git tags first...
DEBUG: Found 1 semver tags with pattern ""
DEBUG: Previous version: 1.0.0
DEBUG: Using "semantic" version bumper (with "")
DEBUG: Previous version tag commit is <hash1>
DEBUG: Iterating over all commits since 2021-03-17 15:32:04 +1100 +1100
DEBUG: Parsing commit <hash3>
DEBUG: Parsing commit <hash2>
DEBUG: Skipping first commit <hash1>
FATAL: Failed to bump version using "semantic": object not found
```

not able to reproduce, but the cause _might_ be an error trying to retrieve and decode a commit before the commit we identified as the "first" commit.
trying a fix: stopping the iteration ourselves when we get to the "first" commit