### PR TITLE
chore: add ability to strip prerelease information from the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It accepts the following CLI flags:
 - `-previous-version`: the [strategy to use to read the previous version](#reading-the-previous-version). Can also be set using the `PREVIOUS_VERSION` environment variable.
 - `-next-version`: the [strategy to use to calculate the next version](#calculating—the-next-version). Can also be set using the `NEXT_VERSION` environment variable.
 - `-output-format`: the [output format of the next release version](#output-format). Can also be set using the `OUTPUT_FORMAT` environment variable.
+- `-strip-prerelease`: remove any prerelease information before calculating the next version. Can also be set using the `STRIP_PRERELEASE` environment variable.
 - `-debug`: if enabled, will print debug logs to stdout in addition to the next version. It can also be enabled by setting the `JX_LOG_LEVEL` environment variable to `debug`.
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ It accepts the following CLI flags:
 - `-previous-version`: the [strategy to use to read the previous version](#reading-the-previous-version). Can also be set using the `PREVIOUS_VERSION` environment variable.
 - `-next-version`: the [strategy to use to calculate the next version](#calculating—the-next-version). Can also be set using the `NEXT_VERSION` environment variable.
 - `-output-format`: the [output format of the next release version](#output-format). Can also be set using the `OUTPUT_FORMAT` environment variable.
-- `-strip-prerelease`: remove any prerelease information before calculating the next version. Can also be set using the `STRIP_PRERELEASE` environment variable.
 - `-debug`: if enabled, will print debug logs to stdout in addition to the next version. It can also be enabled by setting the `JX_LOG_LEVEL` environment variable to `debug`.
 
 ### Features
@@ -105,6 +104,8 @@ Note that if it can't find a tag for the previous version, it will fail.
 
 **Usage**:
 - `jx-release-version -next-version=semantic`
+- if you want to strip any prerelease information from the build before performing the version bump you can use:
+  - `jx-release-version -next-version=semantic:strip-prerelease`
 
 ### From file
 

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 		previousVersion string
 		nextVersion     string
 		outputFormat    string
+		stripPrerelease bool
 	}
 )
 
@@ -42,6 +43,7 @@ func init() {
 	flag.StringVar(&options.previousVersion, "previous-version", getEnvWithDefault("PREVIOUS_VERSION", "auto"), "The strategy to detect the previous version: auto, from-tag, from-file or manual. Default to the PREVIOUS_VERSION env var.")
 	flag.StringVar(&options.nextVersion, "next-version", getEnvWithDefault("NEXT_VERSION", "auto"), "The strategy to calculate the next version: auto, semantic, from-file, increment or manual. Default to the NEXT_VERSION env var.")
 	flag.StringVar(&options.outputFormat, "output-format", getEnvWithDefault("OUTPUT_FORMAT", "{{.Major}}.{{.Minor}}.{{.Patch}}"), "The output format of the next version. Default to the OUTPUT_FORMAT env var.")
+	flag.BoolVar(&options.stripPrerelease, "strip-prerelease", os.Getenv("STRIP_PRERELEASE") == "true", "Strip prerelease from the discovered version before bumping.")
 	flag.BoolVar(&options.debug, "debug", os.Getenv("JX_LOG_LEVEL") == "debug", "Print debug logs. Enabled by default if the JX_LOG_LEVEL env var is set to 'debug'.")
 	flag.BoolVar(&options.printVersion, "version", false, "Just print the version and do nothing.")
 }
@@ -137,12 +139,14 @@ func versionBumper() strategy.VersionBumper {
 	case "auto", "":
 		versionBumper = auto.Strategy{
 			SemanticStrategy: semantic.Strategy{
-				Dir: options.dir,
+				Dir:             options.dir,
+				StripPrerelease: options.stripPrerelease,
 			},
 		}
 	case "semantic":
 		versionBumper = semantic.Strategy{
-			Dir: options.dir,
+			Dir:             options.dir,
+			StripPrerelease: options.stripPrerelease,
 		}
 	case "from-file":
 		versionBumper = fromfile.Strategy{

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ var (
 		previousVersion string
 		nextVersion     string
 		outputFormat    string
-		stripPrerelease bool
 	}
 )
 
@@ -43,7 +42,6 @@ func init() {
 	flag.StringVar(&options.previousVersion, "previous-version", getEnvWithDefault("PREVIOUS_VERSION", "auto"), "The strategy to detect the previous version: auto, from-tag, from-file or manual. Default to the PREVIOUS_VERSION env var.")
 	flag.StringVar(&options.nextVersion, "next-version", getEnvWithDefault("NEXT_VERSION", "auto"), "The strategy to calculate the next version: auto, semantic, from-file, increment or manual. Default to the NEXT_VERSION env var.")
 	flag.StringVar(&options.outputFormat, "output-format", getEnvWithDefault("OUTPUT_FORMAT", "{{.Major}}.{{.Minor}}.{{.Patch}}"), "The output format of the next version. Default to the OUTPUT_FORMAT env var.")
-	flag.BoolVar(&options.stripPrerelease, "strip-prerelease", os.Getenv("STRIP_PRERELEASE") == "true", "Strip prerelease from the discovered version before bumping.")
 	flag.BoolVar(&options.debug, "debug", os.Getenv("JX_LOG_LEVEL") == "debug", "Print debug logs. Enabled by default if the JX_LOG_LEVEL env var is set to 'debug'.")
 	flag.BoolVar(&options.printVersion, "version", false, "Just print the version and do nothing.")
 }
@@ -140,13 +138,13 @@ func versionBumper() strategy.VersionBumper {
 		versionBumper = auto.Strategy{
 			SemanticStrategy: semantic.Strategy{
 				Dir:             options.dir,
-				StripPrerelease: options.stripPrerelease,
+				StripPrerelease: strings.Contains(strategyArg, "strip-prerelease"),
 			},
 		}
 	case "semantic":
 		versionBumper = semantic.Strategy{
 			Dir:             options.dir,
-			StripPrerelease: options.stripPrerelease,
+			StripPrerelease: strings.Contains(strategyArg, "strip-prerelease"),
 		}
 	case "from-file":
 		versionBumper = fromfile.Strategy{

--- a/strategy/semantic/semantic.go
+++ b/strategy/semantic/semantic.go
@@ -18,7 +18,8 @@ var (
 )
 
 type Strategy struct {
-	Dir string
+	Dir             string
+	StripPrerelease bool
 }
 
 func (s Strategy) BumpVersion(previous semver.Version) (*semver.Version, error) {
@@ -46,6 +47,13 @@ func (s Strategy) BumpVersion(previous semver.Version) (*semver.Version, error) 
 	summary, err := s.parseCommitsSince(repo, tagCommit)
 	if err != nil {
 		return nil, err
+	}
+
+	if s.StripPrerelease {
+		previous, err = previous.SetPrerelease("")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var version semver.Version


### PR DESCRIPTION
Add a flag to strip the prerelease information from the determined version before bumping. e.g.

Before:

`1.0.0-something` -> `1.0.0`

After (with the flag set)

`1.0.0-something` -> `1.0.1`

This behaviour will make prerelease act more like build metadata with the advantage that build metadata cannot be added to a docker image version, but prerelease can.