### PR TITLE
fix: support repos with no semver tags

### DIFF
--- a/pkg/strategy/auto/auto.go
+++ b/pkg/strategy/auto/auto.go
@@ -19,8 +19,8 @@ func (s Strategy) ReadVersion() (*semver.Version, error) {
 		return v, nil
 	}
 
-	if err == fromtag.ErrNoTags {
-		log.Logger().Debug("The git repository has no tags yet - returning fake version 0.0.0")
+	if err == fromtag.ErrNoTags || err == fromtag.ErrNoSemverTags {
+		log.Logger().Debugf("Using fake version 0.0.0 because %s", err)
 		return semver.MustParse("0.0.0"), nil
 	}
 

--- a/pkg/strategy/fromtag/from_tag.go
+++ b/pkg/strategy/fromtag/from_tag.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	ErrNoTags = errors.New("the git repository has no tags")
+	ErrNoTags       = errors.New("the git repository has no tags")
+	ErrNoSemverTags = errors.New("the git repository has no semver tags")
 )
 
 type Strategy struct {
@@ -76,6 +77,9 @@ func (s Strategy) ReadVersion() (*semver.Version, error) {
 	}
 	if tags == 0 {
 		return nil, ErrNoTags
+	}
+	if len(versions) == 0 && len(s.TagPattern) == 0 {
+		return nil, ErrNoSemverTags
 	}
 	if len(versions) == 0 {
 		return nil, fmt.Errorf("no semver tags with pattern %q found", s.TagPattern)


### PR DESCRIPTION
see https://kubernetes.slack.com/archives/C9MBGQJRH/p1618362995075700

if a repo has tags but no semver tags, let's fallback nicely to creating a first semver tag, instead of returning an error