### PR TITLE
fix: update alpine version to try to get away from docker version caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 COPY ./build/linux/jx-release-version /usr/bin/jx-release-version
 COPY ./hack/github-actions-entrypoint.sh /usr/bin/github-actions-entrypoint.sh


### PR DESCRIPTION
We're seeing issues with a character being added when jx-release-version is outputted to a file via the command line.