### PR TITLE
feat: allow generate semantic version from `-commit-headlines` CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Just run `jx-release-version` in your project's top directory, and it should jus
 It accepts the following CLI flags:
 - `-dir`: the location on the filesystem of your project's top directory - default to the current working directory.
 - `-previous-version`: the [strategy to use to read the previous version](#reading-the-previous-version). Can also be set using the `PREVIOUS_VERSION` environment variable. Default to `auto`.
+- `-commit-headlines`: the [commit headlines to use to generate the next semantic version](#pass-commit-headlines). Can also be set using the `COMMIT_HEADLINES` environment variable. Default to ``.
 - `-next-version`: the [strategy to use to calculate the next version](#calculating—the-next-version). Can also be set using the `NEXT_VERSION` environment variable. Default to `auto`.
 - `-output-format`: the [output format of the next release version](#output-format). Can also be set using the `OUTPUT_FORMAT` environment variable. Default to `{{.Major}}.{{.Minor}}.{{.Patch}}`.
 - `-tag`: if enabled, [a new tag will be created](#tag). Can also be set using the `TAG` environment variable with the `"TRUE"` value.
@@ -111,12 +112,17 @@ The `semantic` strategy finds all commits between the previous version's git tag
 - at least 1 commit with a `feat:` prefix, then it will bump the minor component of the version
 - otherwise it will bump the patch component of the version
 
-Note that if it can't find a tag for the previous version, it will fail.
+Note that if it can't find a tag for the previous version, it will fail, except if you use the `-commit-headlines` flags to generate semantic next version from a single/multiline string instead of repository commits/tags.
 
 **Usage**:
 - `jx-release-version -next-version=semantic`
 - if you want to strip any prerelease information from the build before performing the version bump you can use:
   - `jx-release-version -next-version=semantic:strip-prerelease`
+
+#### Pass commit headlines
+If you want to retrieve a semantic version without using tags or commits from a repository, you can manually set the previous version and the commit headlines to use:
+  - `jx-release-version -previous-version=1.2.3 -commit-headlines="feat: a feature"`
+
 
 ### From file
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ var (
 		debug           bool
 		dir             string
 		previousVersion string
+		commitHeadlines string
 		nextVersion     string
 		outputFormat    string
 		tag             bool
@@ -47,6 +48,7 @@ func init() {
 	wd, _ := os.Getwd()
 	flag.StringVar(&options.dir, "dir", wd, "The directory that contains the git repository. Default to the current working directory.")
 	flag.StringVar(&options.previousVersion, "previous-version", getEnvWithDefault("PREVIOUS_VERSION", "auto"), "The strategy to detect the previous version: auto, from-tag, from-file or manual. Default to the PREVIOUS_VERSION env var.")
+	flag.StringVar(&options.commitHeadlines, "commit-headlines", getEnvWithDefault("COMMIT_HEADLINES", ""), "The commit headline(s) to use for semantic next version instead of the commit()s of a repository. Default to empty.")
 	flag.StringVar(&options.nextVersion, "next-version", getEnvWithDefault("NEXT_VERSION", "auto"), "The strategy to calculate the next version: auto, semantic, from-file, increment or manual. Default to the NEXT_VERSION env var.")
 	flag.StringVar(&options.outputFormat, "output-format", getEnvWithDefault("OUTPUT_FORMAT", "{{.Major}}.{{.Minor}}.{{.Patch}}"), "The output format of the next version. Default to the OUTPUT_FORMAT env var.")
 	flag.BoolVar(&options.debug, "debug", os.Getenv("JX_LOG_LEVEL") == "debug", "Print debug logs. Enabled by default if the JX_LOG_LEVEL env var is set to 'debug'.")
@@ -167,14 +169,16 @@ func versionBumper() strategy.VersionBumper {
 	case "auto", "":
 		versionBumper = auto.Strategy{
 			SemanticStrategy: semantic.Strategy{
-				Dir:             options.dir,
-				StripPrerelease: strings.Contains(strategyArg, "strip-prerelease"),
+				Dir:                   options.dir,
+				StripPrerelease:       strings.Contains(strategyArg, "strip-prerelease"),
+				CommitHeadlinesString: options.commitHeadlines,
 			},
 		}
 	case "semantic":
 		versionBumper = semantic.Strategy{
-			Dir:             options.dir,
-			StripPrerelease: strings.Contains(strategyArg, "strip-prerelease"),
+			Dir:                   options.dir,
+			StripPrerelease:       strings.Contains(strategyArg, "strip-prerelease"),
+			CommitHeadlinesString: options.commitHeadlines,
 		}
 	case "from-file":
 		versionBumper = fromfile.Strategy{

--- a/pkg/strategy/semantic/semantic_test.go
+++ b/pkg/strategy/semantic/semantic_test.go
@@ -36,6 +36,48 @@ func TestBumpVersion(t *testing.T) {
 			previous: *semver.MustParse("1.1.0"),
 			expected: semver.MustParse("2.0.0"),
 		},
+		{
+			name: "feat from commit headline",
+			strategy: Strategy{
+				CommitHeadlinesString: "feat: a feature",
+			},
+			previous: *semver.MustParse("2.0.0"),
+			expected: semver.MustParse("2.1.0"),
+		},
+		{
+			name: "feat from commit headlines",
+			strategy: Strategy{
+				CommitHeadlinesString: `chore: a chore
+feat: a feature`,
+			},
+			previous: *semver.MustParse("2.0.0"),
+			expected: semver.MustParse("2.1.0"),
+		},
+		{
+			name: "breaking change from commit headline",
+			strategy: Strategy{
+				CommitHeadlinesString: "feat!: a breaking feature",
+			},
+			previous: *semver.MustParse("1.1.0"),
+			expected: semver.MustParse("2.0.0"),
+		},
+		{
+			name: "breaking change from commit headlines",
+			strategy: Strategy{
+				CommitHeadlinesString: `chore: a chore
+feat!: a breaking feature`,
+			},
+			previous: *semver.MustParse("1.1.0"),
+			expected: semver.MustParse("2.0.0"),
+		},
+		{
+			name: "patch from unrecognized commit headline",
+			strategy: Strategy{
+				CommitHeadlinesString: "nothing",
+			},
+			previous: *semver.MustParse("1.1.0"),
+			expected: semver.MustParse("1.1.1"),
+		},
 	}
 
 	// the git repo is stored as a tar.gz archive to make it easy to commit


### PR DESCRIPTION
This PR allows to generate a semantic next version from a previous one without the need for a (valid) tag or commit(s) from a repository.

### Use case
A helm charts repository  (https://github.com/jenkins-infra/helm-charts) containing [multiple unrelated git tags](https://github.com/jenkins-infra/helm-charts/releases) with a prefix corresponding to their chart name, making the tag (ex: `acme-1.2.3`) `semantic`ally invalid to use with `-next-version=from-tag:acme-1.2.3` argument (even with a `-tag-prefix="acme-"` additional flag).

### Example of usage
```
$ jx-release-version -previous-version=manual:1.2.3 -commit-headlines="feat: a feature"
1.3.0

$ jx-release-version --previous-version=from-file:helm-charts/charts/acme/Chart.yaml -commit-headlines="feat: a feature" -debug
DEBUG: jx-release-version 2.6.11-dev+8acbdc5 running in debug mode in /Users/veve/j-infra
DEBUG: Using "from-file" version reader (with "helm-charts/charts/acme/Chart.yaml")
DEBUG: Reading version from file /Users/veve/j-infra/helm-charts/charts/acme/Chart.yaml using reader helm-chart
DEBUG: Found version 0.1.2
DEBUG: Previous version: 0.1.2
DEBUG: Using "auto" version bumper (with "")
DEBUG: Trying to bump the version using semantic release first...
DEBUG: Iterating over all commits headline passed as a string
DEBUG: Parsing commit headline number 0 with message feat: stuff
DEBUG: Summary of conventional commits: semantic.conventionalCommitsSummary{conventionalCommitsCount:1, types:map[string]bool{"feat":true}, breakingChanges:false}
DEBUG: Found at least 1 new feature - incrementing minor component
DEBUG: Next version: 0.2.0
0.2.0
````
Works even without a git repository.

### Potential improvement


Related: https://github.com/jenkins-x-plugins/jx-release-version/issues/84#issuecomment-1675315721