### PR TITLE
fix: send progress output to stderr while fetching and pushing

### DIFF
--- a/pkg/strategy/fromfile/maven_pom.go
+++ b/pkg/strategy/fromfile/maven_pom.go
@@ -23,7 +23,7 @@ func (r MavenPOMVersionReader) SupportedFiles() []string {
 }
 
 func (r MavenPOMVersionReader) ReadFileVersion(filePath string) (string, error) {
-	log.Logger().Debugf("using path " + os.Getenv("PATH"))
+	log.Logger().Debugf("using path %s", os.Getenv("PATH"))
 	path, err := exec.LookPath("mvn")
 	if err != nil {
 		log.Logger().Debugf("Maven does not appear to be installed, reading directly from %s", filePath)

--- a/pkg/strategy/fromtag/from_tag.go
+++ b/pkg/strategy/fromtag/from_tag.go
@@ -54,7 +54,6 @@ func (s Strategy) ReadVersion() (*semver.Version, error) {
 		log.Logger().Debug("Fetching tags from origin")
 		err = repo.Fetch(&git.FetchOptions{
 			RemoteName: "origin",
-			Progress:   os.Stdout,
 			RefSpecs:   []config.RefSpec{config.RefSpec("refs/tags/*:refs/tags/*")},
 		})
 		if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {

--- a/pkg/strategy/fromtag/from_tag.go
+++ b/pkg/strategy/fromtag/from_tag.go
@@ -54,6 +54,7 @@ func (s Strategy) ReadVersion() (*semver.Version, error) {
 		log.Logger().Debug("Fetching tags from origin")
 		err = repo.Fetch(&git.FetchOptions{
 			RemoteName: "origin",
+			Progress:   os.Stderr,
 			RefSpecs:   []config.RefSpec{config.RefSpec("refs/tags/*:refs/tags/*")},
 		})
 		if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {

--- a/pkg/tag/tag.go
+++ b/pkg/tag/tag.go
@@ -74,6 +74,7 @@ func pushTags(r *git.Repository) error {
 
 	po := &git.PushOptions{
 		RemoteName: "origin",
+		Progress:   os.Stderr,
 		RefSpecs:   []config.RefSpec{config.RefSpec("refs/tags/*:refs/tags/*")},
 	}
 


### PR DESCRIPTION
This PR is to send progress output from git fetch and push to stderr.

Before the PR, the git fetch progress is sent to stdout which is prepended to the version that is also output to stdout by jx-release-version.

I added the progress to stderr for git push to be consistent with the git fetch behavior.