### PR TITLE
feat(cli): add --print-previous-version flag and expose previous-version action output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Just run `jx-release-version` in your project's top directory, and it should jus
 It accepts the following CLI flags:
 - `-dir`: the location on the filesystem of your project's top directory - default to the current working directory.
 - `-previous-version`: the [strategy to use to read the previous version](#reading-the-previous-version). Can also be set using the `PREVIOUS_VERSION` environment variable. Default to `auto`.
+- `-print-previous-version`: if enabled, print the previous version detected by the `-previous-version` strategy instead of calculating and printing the next version.
 - `-commit-headlines`: the [commit headlines to use to generate the next semantic version](#pass-commit-headlines). Can also be set using the `COMMIT_HEADLINES` environment variable. Default to ``.
 - `-next-version`: the [strategy to use to calculate the next version](#calculating—the-next-version). Can also be set using the `NEXT_VERSION` environment variable. Default to `auto`.
 - `-output-format`: the [output format of the next release version](#output-format). Can also be set using the `OUTPUT_FORMAT` environment variable. Default to `{{.Major}}.{{.Minor}}.{{.Patch}}`.
@@ -92,6 +93,14 @@ The `manual` strategy can be used if you already know the previous version, and 
 **Usage**:
 - `jx-release-version -previous-version=manual:1.2.3`
 - `jx-release-version -previous-version=1.2.3` - the `manual` prefix is optional
+
+### Print the previous version
+
+If you only need the previous version, use `-print-previous-version`. It reads the previous version using the configured `-previous-version` strategy and prints it without calculating the next version or creating a tag.
+
+**Usage**:
+- `jx-release-version -print-previous-version`
+- `jx-release-version -previous-version=from-file:Chart.yaml -print-previous-version`
 
 ## Calculating the next version
 
@@ -232,6 +241,8 @@ jobs:
         env:
           VERSION: ${{ steps.nextversion.outputs.version }}
 ```
+
+The action also exposes the previous version detected by the `previous-version` strategy as `steps.<id>.outputs.previous-version`.
 
 Or to create a new tag and push it, you can:
 - use the [fregante/setup-git-user](https://github.com/fregante/setup-git-user) action to setup the git name/email to the [github-actions bot](https://github.com/apps/github-actions)

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@
 name: 'jx-release-version'
 description: 'https://github.com/jenkins-x-plugins/jx-release-version'
 branding:
-  icon: 'tag'  
+  icon: 'tag'
   color: 'blue'
 inputs:
   previous-version:
@@ -44,6 +44,8 @@ inputs:
 outputs:
   version:
     description: 'The next release version'
+  previous-version:
+    description: 'The previous release version detected by the previous-version strategy'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/jenkins-x/jx-release-version:2.7.10'

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ outputs:
     description: 'The previous release version detected by the previous-version strategy'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/jenkins-x/jx-release-version:2.7.10'
+  image: 'docker://ghcr.io/jenkins-x/jx-release-version:2.8.5'
   entrypoint: 'github-actions-entrypoint.sh'
   env:
     PREVIOUS_VERSION: ${{ inputs.previous-version }}

--- a/hack/github-actions-entrypoint.sh
+++ b/hack/github-actions-entrypoint.sh
@@ -2,3 +2,6 @@
 
 version=$(jx-release-version)
 echo "version=$version" >> $GITHUB_OUTPUT
+
+previous_version=$(jx-release-version --print-previous-version)
+echo "previous-version=$previous_version" >> $GITHUB_OUTPUT

--- a/main.go
+++ b/main.go
@@ -28,19 +28,20 @@ var (
 
 	// CLI flag options
 	options struct {
-		printVersion    bool
-		debug           bool
-		dir             string
-		previousVersion string
-		commitHeadlines string
-		nextVersion     string
-		outputFormat    string
-		tag             bool
-		tagPrefix       string
-		pushTag         bool
-		fetchTags       bool
-		gitName         string
-		gitEmail        string
+		printVersion         bool
+		printPreviousVersion bool
+		debug                bool
+		dir                  string
+		previousVersion      string
+		commitHeadlines      string
+		nextVersion          string
+		outputFormat         string
+		tag                  bool
+		tagPrefix            string
+		pushTag              bool
+		fetchTags            bool
+		gitName              string
+		gitEmail             string
 	}
 )
 
@@ -53,6 +54,7 @@ func init() {
 	flag.StringVar(&options.outputFormat, "output-format", getEnvWithDefault("OUTPUT_FORMAT", "{{.Major}}.{{.Minor}}.{{.Patch}}"), "The output format of the next version. Default to the OUTPUT_FORMAT env var.")
 	flag.BoolVar(&options.debug, "debug", os.Getenv("JX_LOG_LEVEL") == "debug", "Print debug logs. Enabled by default if the JX_LOG_LEVEL env var is set to 'debug'.")
 	flag.BoolVar(&options.printVersion, "version", false, "Just print the version and do nothing.")
+	flag.BoolVar(&options.printPreviousVersion, "print-previous-version", false, "Instead of printing the next version, print the previous (current) version detected by the previous-version strategy.")
 	flag.BoolVar(&options.tag, "tag", os.Getenv("TAG") == "true", "Perform a git tag")
 	flag.StringVar(&options.tagPrefix, "tag-prefix", getEnvWithDefault("TAG_PREFIX", "v"), "Prefix to use for the git tag")
 	flag.BoolVar(&options.pushTag, "push-tag", getEnvWithDefault("PUSH_TAG", "true") == "true", "Use with tag flag, pushes a git tag to the remote branch")
@@ -79,6 +81,11 @@ func main() {
 		log.Logger().Fatalf("Failed to read previous version using %q: %v", options.previousVersion, err)
 	}
 	log.Logger().Debugf("Previous version: %s", previousVersion.String())
+
+	if options.printPreviousVersion {
+		fmt.Print(previousVersion.Original())
+		return
+	}
 
 	nextVersion, err := versionBumper().BumpVersion(*previousVersion)
 	if err != nil {


### PR DESCRIPTION
Add a --print-previous-version flag to the binary that reads the previous version using the configured strategy, formats it with the output-format template, and prints it without performing a version bump or tag.

Update the GitHub Actions entrypoint to run the binary with this flag and write the result to GITHUB_OUTPUT as previous-version. Expose previous-version as an action output in action.yml so callers can reference it via steps.<id>.outputs.previous-version.