### PR TITLE
fix: avoid attempting to set the same tag as the previous

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func init() {
 	wd, _ := os.Getwd()
 	flag.StringVar(&options.dir, "dir", wd, "The directory that contains the git repository. Default to the current working directory.")
 	flag.StringVar(&options.previousVersion, "previous-version", getEnvWithDefault("PREVIOUS_VERSION", "auto"), "The strategy to detect the previous version: auto, from-tag, from-file or manual. Default to the PREVIOUS_VERSION env var.")
-	flag.StringVar(&options.commitHeadlines, "commit-headlines", getEnvWithDefault("COMMIT_HEADLINES", ""), "The commit headline(s) to use for semantic next version instead of the commit()s of a repository. Default to empty.")
+	flag.StringVar(&options.commitHeadlines, "commit-headlines", getEnvWithDefault("COMMIT_HEADLINES", ""), "The commit headline(s) to use for semantic next version instead of the commit()s of a repository. Default to empty. Mainly for testing.")
 	flag.StringVar(&options.nextVersion, "next-version", getEnvWithDefault("NEXT_VERSION", "auto"), "The strategy to calculate the next version: auto, semantic, from-file, increment or manual. Default to the NEXT_VERSION env var.")
 	flag.StringVar(&options.outputFormat, "output-format", getEnvWithDefault("OUTPUT_FORMAT", "{{.Major}}.{{.Minor}}.{{.Patch}}"), "The output format of the next version. Default to the OUTPUT_FORMAT env var.")
 	flag.BoolVar(&options.strictSemver, "strict-semver", false, "Use strict semver validation for the manual strategy. Rejects partial versions (e.g. '1', '1.2') and versions with leading zeros (e.g. '2026.06.29').")
@@ -60,7 +60,7 @@ func init() {
 	flag.BoolVar(&options.printPreviousVersion, "print-previous-version", false, "Instead of printing the next version, print the previous (current) version detected by the previous-version strategy.")
 	flag.BoolVar(&options.tag, "tag", os.Getenv("TAG") == "true", "Perform a git tag")
 	flag.StringVar(&options.tagPrefix, "tag-prefix", getEnvWithDefault("TAG_PREFIX", "v"), "Prefix to use for the git tag")
-	flag.StringVar(&options.tagSuffix, "tag-suffix", getEnvWithDefault("TAG_SUFFIX", ""), "Use with tag flag, adds the given suffix to the tag. Typically something like -pre")
+	flag.StringVar(&options.tagSuffix, "tag-suffix", getEnvWithDefault("TAG_SUFFIX", ""), "Suffix to use for the git tag. Typically something like -pre")
 	flag.BoolVar(&options.pushTag, "push-tag", getEnvWithDefault("PUSH_TAG", "true") == "true", "Use with tag flag, pushes a git tag to the remote branch")
 	flag.BoolVar(&options.fetchTags, "fetch-tags", getEnvWithDefault("FETCH_TAGS", "") == "true", "Fetch tags from the remote origin before detecting the previous version")
 	flag.StringVar(&options.gitName, "git-user", getEnvWithDefault("GIT_NAME", ""), "Name is the personal name of the author and the committer of a commit, use to override Git config")
@@ -93,7 +93,7 @@ func main() {
 		return
 	}
 
-	nextVersion, err := versionBumper().BumpVersion(*previousVersion)
+	nextVersion, err := versionBumper().BumpVersion(*previousVersion, options.tagSuffix)
 	if err != nil {
 		log.Logger().Fatalf("Failed to bump version using %q: %v", options.nextVersion, err)
 	}

--- a/pkg/strategy/auto/auto.go
+++ b/pkg/strategy/auto/auto.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/jenkins-x-plugins/jx-release-version/v2/pkg/strategy"
 	"github.com/jenkins-x-plugins/jx-release-version/v2/pkg/strategy/fromtag"
 	"github.com/jenkins-x-plugins/jx-release-version/v2/pkg/strategy/semantic"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
@@ -29,16 +30,16 @@ func (s Strategy) ReadVersion() (*semver.Version, error) {
 	return nil, fmt.Errorf("failed to read previous version from tags: %w", err)
 }
 
-func (s Strategy) BumpVersion(previous semver.Version) (*semver.Version, error) {
+func (s Strategy) BumpVersion(previous semver.Version, tagSuffix string) (*semver.Version, error) {
 	log.Logger().Debug("Trying to bump the version using semantic release first...")
-	v, err := s.SemanticStrategy.BumpVersion(previous)
+	v, err := s.SemanticStrategy.BumpVersion(previous, tagSuffix)
 	if err == nil {
 		return v, nil
 	}
 
 	if err == semantic.ErrPreviousVersionTagNotFound {
 		log.Logger().Debugf("The git repository has no tag for the previous version %s - fallback to incrementing the patch component of the previous version", previous.String())
-		next := previous.IncPatch()
+		next := strategy.IncPatch(previous, tagSuffix)
 		return &next, nil
 	}
 

--- a/pkg/strategy/auto/auto_test.go
+++ b/pkg/strategy/auto/auto_test.go
@@ -76,6 +76,7 @@ func TestBumpVersion(t *testing.T) {
 		previous         semver.Version
 		expected         *semver.Version
 		expectedErrorMsg string
+		tagSuffix        string
 	}{
 		{
 			name: "empty git repo",
@@ -110,6 +111,55 @@ func TestBumpVersion(t *testing.T) {
 			previous: *semver.MustParse("1.0.0"),
 			expected: semver.MustParse("1.1.0"),
 		},
+		{
+			name: "patch bump with prerelease matching tagSuffix",
+			strategy: Strategy{
+				SemanticStrategy: semantic.Strategy{
+					Dir:                   "testdata/git-repo",
+					CommitHeadlinesString: "fix: a fix",
+					TagPrefix:             "v",
+				},
+			},
+			previous:  *semver.MustParse("1.0.0-pre"),
+			tagSuffix: "-pre",
+			expected:  semver.MustParse("1.0.1"),
+		},
+		{
+			name: "patch bump with prerelease not matching tagSuffix",
+			strategy: Strategy{
+				SemanticStrategy: semantic.Strategy{
+					CommitHeadlinesString: "fix: a fix",
+					TagPrefix:             "v",
+				},
+			},
+			previous:  *semver.MustParse("1.0.0-alpha"),
+			tagSuffix: "-pre",
+			expected:  semver.MustParse("1.0.0"),
+		},
+		{
+			name: "patch bump with prerelease and no tagSuffix",
+			strategy: Strategy{
+				SemanticStrategy: semantic.Strategy{
+					CommitHeadlinesString: "fix: a fix",
+					TagPrefix:             "v",
+				},
+			},
+			previous:  *semver.MustParse("1.0.0-pre"),
+			tagSuffix: "",
+			expected:  semver.MustParse("1.0.0"),
+		},
+		{
+			name: "patch bump with prerelease matching tagSuffix in empty repo",
+			strategy: Strategy{
+				SemanticStrategy: semantic.Strategy{
+					Dir:       "testdata/empty-git-repo",
+					TagPrefix: "v",
+				},
+			},
+			previous:  *semver.MustParse("1.0.0-pre"),
+			tagSuffix: "-pre",
+			expected:  semver.MustParse("1.0.1"),
+		},
 	}
 
 	setupGitRepos(t)
@@ -119,7 +169,7 @@ func TestBumpVersion(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// t.Parallel()
 
-			actual, err := test.strategy.BumpVersion(test.previous)
+			actual, err := test.strategy.BumpVersion(test.previous, test.tagSuffix)
 			if test.expectedErrorMsg != "" {
 				require.EqualError(t, err, test.expectedErrorMsg)
 				assert.Nil(t, actual)

--- a/pkg/strategy/fromfile/from_file.go
+++ b/pkg/strategy/fromfile/from_file.go
@@ -71,7 +71,7 @@ func (s Strategy) ReadVersion() (*semver.Version, error) {
 	return semver.NewVersion(version)
 }
 
-func (s Strategy) BumpVersion(_ semver.Version) (*semver.Version, error) {
+func (s Strategy) BumpVersion(_ semver.Version, _ string) (*semver.Version, error) {
 	return s.ReadVersion()
 }
 

--- a/pkg/strategy/increment/increment.go
+++ b/pkg/strategy/increment/increment.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/jenkins-x-plugins/jx-release-version/v2/pkg/strategy"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 )
 
@@ -11,7 +12,7 @@ type Strategy struct {
 	ComponentToIncrement string
 }
 
-func (s Strategy) BumpVersion(previous semver.Version) (*semver.Version, error) {
+func (s Strategy) BumpVersion(previous semver.Version, tagSuffix string) (*semver.Version, error) {
 	var next semver.Version
 	switch strings.ToLower(s.ComponentToIncrement) {
 	case "major":
@@ -22,7 +23,7 @@ func (s Strategy) BumpVersion(previous semver.Version) (*semver.Version, error) 
 		next = previous.IncMinor()
 	default:
 		log.Logger().Debug("Incrementing patch component")
-		next = previous.IncPatch()
+		next = strategy.IncPatch(previous, tagSuffix)
 	}
 	return &next, nil
 }

--- a/pkg/strategy/increment/increment_test.go
+++ b/pkg/strategy/increment/increment_test.go
@@ -17,6 +17,7 @@ func TestBumpVersion(t *testing.T) {
 		previous             semver.Version
 		expected             *semver.Version
 		expectedErrorMsg     string
+		tagSuffix            string
 	}{
 		{
 			name:                 "increment major",
@@ -48,6 +49,23 @@ func TestBumpVersion(t *testing.T) {
 			previous:             *semver.MustParse("1.2.3"),
 			expected:             semver.MustParse("1.3.0"),
 		},
+		{
+			name:      "patch bump with prerelease matching tagSuffix",
+			previous:  *semver.MustParse("1.0.0-pre"),
+			tagSuffix: "-pre",
+			expected:  semver.MustParse("1.0.1"),
+		},
+		{
+			name:      "patch bump with prerelease not matching tagSuffix",
+			previous:  *semver.MustParse("1.0.0-alpha"),
+			tagSuffix: "-pre",
+			expected:  semver.MustParse("1.0.0"),
+		},
+		{
+			name:     "patch bump with prerelease and no tagSuffix",
+			previous: *semver.MustParse("1.0.0-pre"),
+			expected: semver.MustParse("1.0.0"),
+		},
 	}
 
 	for i := range tests {
@@ -58,7 +76,7 @@ func TestBumpVersion(t *testing.T) {
 			s := Strategy{
 				ComponentToIncrement: test.componentToIncrement,
 			}
-			actual, err := s.BumpVersion(test.previous)
+			actual, err := s.BumpVersion(test.previous, test.tagSuffix)
 			if test.expectedErrorMsg != "" {
 				require.EqualError(t, err, test.expectedErrorMsg)
 				assert.Nil(t, actual)

--- a/pkg/strategy/manual/manual.go
+++ b/pkg/strategy/manual/manual.go
@@ -17,7 +17,7 @@ func (s Strategy) ReadVersion() (*semver.Version, error) {
 	return validateAndParse(s.Version, s.Strict)
 }
 
-func (s Strategy) BumpVersion(_ semver.Version) (*semver.Version, error) {
+func (s Strategy) BumpVersion(_ semver.Version, _ string) (*semver.Version, error) {
 	log.Logger().Debugf("Using manual version %s (strict: %v)", s.Version, s.Strict)
 	return validateAndParse(s.Version, s.Strict)
 }

--- a/pkg/strategy/semantic/semantic.go
+++ b/pkg/strategy/semantic/semantic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/jenkins-x-plugins/jx-release-version/v2/pkg/strategy"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
 	"github.com/zbindenren/cc"
 )
@@ -26,7 +27,7 @@ type Strategy struct {
 	TagPrefix             string
 }
 
-func (s Strategy) BumpVersion(previous semver.Version) (*semver.Version, error) {
+func (s Strategy) BumpVersion(previous semver.Version, tagSuffix string) (*semver.Version, error) {
 	var (
 		dir                   = s.Dir
 		err                   error
@@ -76,7 +77,7 @@ func (s Strategy) BumpVersion(previous semver.Version) (*semver.Version, error) 
 		version = previous.IncMinor()
 	default:
 		log.Logger().Debug("Incrementing patch component")
-		version = previous.IncPatch()
+		version = strategy.IncPatch(previous, tagSuffix)
 	}
 
 	return &version, nil

--- a/pkg/strategy/semantic/semantic_test.go
+++ b/pkg/strategy/semantic/semantic_test.go
@@ -19,6 +19,7 @@ func TestBumpVersion(t *testing.T) {
 		name             string
 		strategy         Strategy
 		previous         semver.Version
+		tagSuffix        string
 		expected         *semver.Version
 		expectedErrorMsg string
 	}{
@@ -105,6 +106,36 @@ feat!: a breaking feature`,
 			previous: *semver.MustParse("1.1.0"),
 			expected: semver.MustParse("2.0.0"),
 		},
+		{
+			name: "patch bump with prerelease matching tagSuffix",
+			strategy: Strategy{
+				CommitHeadlinesString: "fix: a fix",
+				TagPrefix:             "v",
+			},
+			previous:  *semver.MustParse("1.0.0-pre"),
+			tagSuffix: "-pre",
+			expected:  semver.MustParse("1.0.1"),
+		},
+		{
+			name: "patch bump with prerelease not matching tagSuffix",
+			strategy: Strategy{
+				CommitHeadlinesString: "fix: a fix",
+				TagPrefix:             "v",
+			},
+			previous:  *semver.MustParse("1.0.0-alpha"),
+			tagSuffix: "-pre",
+			expected:  semver.MustParse("1.0.0"),
+		},
+		{
+			name: "patch bump with prerelease and no tagSuffix",
+			strategy: Strategy{
+				CommitHeadlinesString: "fix: a fix",
+				TagPrefix:             "v",
+			},
+			previous:  *semver.MustParse("1.0.0-pre"),
+			tagSuffix: "",
+			expected:  semver.MustParse("1.0.0"),
+		},
 	}
 
 	// the git repo is stored as a tar.gz archive to make it easy to commit
@@ -119,7 +150,7 @@ feat!: a breaking feature`,
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := test.strategy.BumpVersion(test.previous)
+			actual, err := test.strategy.BumpVersion(test.previous, test.tagSuffix)
 			if test.expectedErrorMsg != "" {
 				require.EqualError(t, err, test.expectedErrorMsg)
 				assert.Nil(t, actual)

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -1,6 +1,8 @@
 package strategy
 
 import (
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 )
 
@@ -9,5 +11,16 @@ type VersionReader interface {
 }
 
 type VersionBumper interface {
-	BumpVersion(previous semver.Version) (*semver.Version, error)
+	BumpVersion(previous semver.Version, tagSuffix string) (*semver.Version, error)
+}
+
+func IncPatch(previous semver.Version, tagSuffix string) semver.Version {
+	if tagSuffix != "" && previous.Prerelease() == strings.TrimPrefix(tagSuffix, "-") {
+		// IncPatch doesn't increase version if pre release is set, instead it is cleared.
+		// Since the latest version has the same pre release as would be set here we would end up
+		// trying to change the previous tag.
+		// Instead the first IncPatch clears pre release before the actual increment.
+		previous = previous.IncPatch()
+	}
+	return previous.IncPatch()
 }


### PR DESCRIPTION
This could happen when the previousrelease pipeline failed, as just happened in https://dashboard-jx.infra.jenkins-x.rocks/ns-jx/jenkins-x/jx-helpers/HEAD/1

It turns out that IncPatch on 1.0.0-pre gives 1.0.0, not 1.0.1 as I expected...

Part of fix for jenkins-x/jx#9036